### PR TITLE
Handle newlines in the data properly

### DIFF
--- a/src/sse.ts
+++ b/src/sse.ts
@@ -17,7 +17,9 @@ export function serializeSSEEvent(chunk: EventMessage): string {
     payload += `event: ${chunk.event}\n`;
   }
   if (chunk.data) {
-    payload += `data: ${chunk.data}\n`;
+    for (const line of chunk.data.split('\n')) {
+      payload += `data: ${line}\n`;
+    }
   }
   if (chunk.retry) {
     payload += `retry: ${chunk.retry}\n`;


### PR DESCRIPTION
If `chunk.data` has newlines in it, only the first line is passed on since `data: ` is prefixed only to the first line. SSE requires all lines to have `data: `. See https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#data